### PR TITLE
Fetch ImageMagick from Github.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ ENV PATH="/usr/share/jenkins/scripts:${PATH}"
 RUN /usr/share/jenkins/scripts/h264-analyze-install
 
 # Install ImageMagick
-# RUN /usr/share/jenkins/scripts/magick-install
+RUN /usr/share/jenkins/scripts/magick-install
 
 # Install tesseract
 RUN /usr/share/jenkins/scripts/tesseract-install

--- a/scripts/magick-install
+++ b/scripts/magick-install
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -eux
 
-# Reference: https://www.imagemagick.org/script/install-source.php
-
-CHECKOUT_DIR=ImageMagick-7.0.8-14
+VERSION=7.0.8-14
+CHECKOUT_DIR=ImageMagick-${VERSION}
 
 cd /tmp
 
-wget https://www.imagemagick.org/download/${CHECKOUT_DIR}.tar.gz
+wget -O ${CHECKOUT_DIR}.tar.gz https://github.com/ImageMagick/ImageMagick/archive/${VERSION}.tar.gz
+
 tar xvzf ${CHECKOUT_DIR}.tar.gz
 cd ${CHECKOUT_DIR}
 ./configure


### PR DESCRIPTION
Fetch ImageMagick from Github instead of www.imagemagick.org.
imagemagick.org is currently unreachable.